### PR TITLE
Fixed category delete functionality

### DIFF
--- a/SQL/02_TabloidMVC_Seed_Data.sql
+++ b/SQL/02_TabloidMVC_Seed_Data.sql
@@ -8,7 +8,7 @@ SET IDENTITY_INSERT [UserType] OFF
 
 SET IDENTITY_INSERT [Category] ON
 INSERT INTO [Category] ([Id], [Name]) 
-VALUES (1, 'Technology'), (2, 'Close Magic'), (3, 'Politics'), (4, 'Science'), (5, 'Improv'), 
+VALUES (1, 'Other'), (2, 'Close Magic'), (3, 'Politics'), (4, 'Science'), (5, 'Improv'), 
 	   (6, 'Cthulhu Sightings'), (7, 'History'), (8, 'Home and Garden'), (9, 'Entertainment'), 
 	   (10, 'Cooking'), (11, 'Music'), (12, 'Movies'), (13, 'Regrets');
 SET IDENTITY_INSERT [Category] OFF

--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -28,12 +28,6 @@ namespace TabloidMVC.Controllers
             return View(categories);
         }
 
-        // GET: CategoryController/Details/5
-        public ActionResult Details(int id)
-        {
-            return View();
-        }
-
         // GET: CategoryController/Create
         public ActionResult Create()
         {
@@ -62,7 +56,7 @@ namespace TabloidMVC.Controllers
         {
             Category category = _categoryRepo.GetCategoryById(id);
 
-            if (category == null)
+            if (category == null || id == 1)
             {
                 return NotFound();
             }
@@ -92,7 +86,7 @@ namespace TabloidMVC.Controllers
         {
             Category category = _categoryRepo.GetCategoryById(id);
 
-            if (category == null)
+            if (category == null || id == 1)
             {
                 return NotFound();
             }

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -111,7 +111,7 @@ namespace TabloidMVC.Repositories
                     cmd.CommandText = @"
                             UPDATE Category
                             SET [Name] = @name 
-                            WHERE Id = @id";
+                            WHERE Id = @id AND Id != 1;";
 
                     cmd.Parameters.AddWithValue("@name", category.Name);
                     cmd.Parameters.AddWithValue("@id", category.Id);
@@ -131,8 +131,11 @@ namespace TabloidMVC.Repositories
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = @"
+                            UPDATE Post
+                            SET CategoryId = 1
+                            WHERE CategoryId = @id;
                             DELETE FROM Category
-                            WHERE Id = @id
+                            WHERE Id = @id AND Id != 1;
                         ";
 
                     cmd.Parameters.AddWithValue("@id", categoryId);

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -49,7 +49,7 @@ namespace TabloidMVC.Repositories
                     cmd.CommandText = @"
                         SELECT Id, [Name]
                         FROM Category
-                        WHERE Id = @id
+                        WHERE Id = @id AND Id != 1
                     ";
 
                     cmd.Parameters.AddWithValue("@id", id);

--- a/TabloidMVC/Views/Category/Index.cshtml
+++ b/TabloidMVC/Views/Category/Index.cshtml
@@ -20,15 +20,23 @@
     </thead>
     <tbody>
 @foreach (var item in Model) {
+        
         <tr>
             <td>
                 @Html.DisplayFor(modelItem => item.Name)
             </td>
-            <td>
-                @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new { id = item.Id})
-            </td>
+            @if (item.Id != 1)
+            {
+                <td>
+                    @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
+                    @Html.ActionLink("Delete", "Delete", new { id = item.Id })
+                </td>
+            }
+            else
+            {
+                <td></td>
+            }
         </tr>
-}
+    }
     </tbody>
 </table>


### PR DESCRIPTION
Deleting a category now changes any post with said category to other and deletes the selected category. Other should be immune to being deleted or edited.

Testing:
- Try deleting a category associated with a post
- Upon deletion, the category should disappear and the post's category should be set to other
- Look for any way to delete or edit the 'other' category whose id = 1