### PR TITLE
Bl post comment fix

### DIFF
--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -56,11 +56,18 @@ namespace TabloidMVC.Controllers
         // GET: Comment/Create
         public ActionResult Create(int postId)
         {
-            Comment comment = new Comment()
+            
+            Post post = _postRepo.GetPublishedPostById(postId);
+
+            if(post != null)
             {
-                PostId = postId
-            };
-            return View(comment);
+                Comment comment = new Comment()
+                {
+                    PostId = postId
+                };
+                return View(comment);
+            }
+            return NotFound();     
         }
 
         // POST: Comment/Create

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -43,7 +43,10 @@
                     @Html.DisplayFor(modelItem => item.CreateDateTime)
                 </td>
                 <td>
-                    @Html.ActionLink("Edit", "Edit", new {  id=item.Id  }) |
+                    @if (Model.Post.PublishDateTime <= DateTime.Now)
+                    {
+                        @Html.ActionLink("Edit", "Edit", new { id = item.Id });
+                    }
                     @Html.ActionLink("Delete", "Delete", new { id = item.Id })
                 </td>
             </tr>

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -43,10 +43,7 @@
                     @Html.DisplayFor(modelItem => item.CreateDateTime)
                 </td>
                 <td>
-                    @if (Model.Post.PublishDateTime <= DateTime.Now)
-                    {
-                        @Html.ActionLink("Edit", "Edit", new { id = item.Id });
-                    }
+                    @Html.ActionLink("Edit", "Edit", new { id = item.Id })|
                     @Html.ActionLink("Delete", "Delete", new { id = item.Id })
                 </td>
             </tr>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -40,11 +40,13 @@
         <section class="row post__tags">
             @foreach (PostTag postTag in Model.PostTags)
             {
-                 <span class="badge badge-secondary">@postTag.Tag.Name</span>
+                <span class="badge badge-secondary">@postTag.Tag.Name</span>
             }
         </section>
-
-        <a class="btn btn-outline-dark" href="@Url.Action("Index", "Comment", new { postId = Model.Post.Id })">Comments</a>
+        @if (Model.Post.PublishDateTime <= DateTime.Now)
+        {
+            <a class="btn btn-outline-dark" href="@Url.Action("Index", "Comment", new { postId = Model.Post.Id })">Comments</a>
+        }
         <a class="btn btn-outline-dark" href="@Url.Action("Index", "PostTag", new { postId = Model.Post.Id })">Manage Tags</a>
     </div>
 </div>


### PR DESCRIPTION
Testing:
- Navigate to a post's details page that has a future publish date
- The comments link should not be displayed
- Try to navigate in the url to create a comment for a post that is either not published yet or doesn't exist: https://localhost:5001/Comment/Create?postId=12