### PR TITLE
users can now only edit and delete their own comments

### DIFF
--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -38,6 +38,7 @@ namespace TabloidMVC.Controllers
             {
                 new Claim(ClaimTypes.NameIdentifier, userProfile.Id.ToString()),
                 new Claim(ClaimTypes.Email, userProfile.Email),
+                new Claim(ClaimTypes.Role, userProfile.UserTypeId.ToString())
             };
 
             var claimsIdentity = new ClaimsIdentity(

--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -139,8 +139,10 @@ namespace TabloidMVC.Controllers
             //get the current user
             int userId = GetCurrentUserId();
 
+            int userType = GetCurrentUserTypeId();
+
             //if null or current user is not the user who made the comment, return not found
-            if (comment == null || userId != comment.UserProfileId)
+            if (comment == null || (userId != comment.UserProfileId && userType != 1))
             {
                 return NotFound();
             }
@@ -168,6 +170,14 @@ namespace TabloidMVC.Controllers
         private int GetCurrentUserId()
         {
             string id = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            return int.Parse(id);
+        }
+
+        private int GetCurrentUserTypeId()
+        {
+            string id = User.FindFirstValue(ClaimTypes.Role);
+
             return int.Parse(id);
         }
     }

--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -100,8 +100,11 @@ namespace TabloidMVC.Controllers
             //get the comment
             Comment comment = _commentRepo.GetCommentById(id);
 
-            //if null, return not found
-            if(comment == null)
+            //get the current user
+            int userId = GetCurrentUserId();
+
+            //if null or current user is not the user who made the comment, return not found
+            if(comment == null || userId != comment.UserProfileId)
             {
                 return NotFound();
             }
@@ -130,8 +133,14 @@ namespace TabloidMVC.Controllers
         // GET: Comment/Delete/5
         public ActionResult Delete(int id)
         {
+            //get the comment
             Comment comment = _commentRepo.GetCommentById(id);
-            if(comment == null)
+
+            //get the current user
+            int userId = GetCurrentUserId();
+
+            //if null or current user is not the user who made the comment, return not found
+            if (comment == null || userId != comment.UserProfileId)
             {
                 return NotFound();
             }

--- a/TabloidMVC/Repositories/CommentRepository.cs
+++ b/TabloidMVC/Repositories/CommentRepository.cs
@@ -95,7 +95,7 @@ namespace TabloidMVC.Repositories
                     //create and execute command
                     cmd.CommandText = @"
                         SELECT Id, PostId, UserProfileId, [Subject], Content, CreateDateTime
-                        FROM Comment
+                        FROM Comment c
                         WHERE Id = @id
                     ";
 

--- a/TabloidMVC/Repositories/CommentRepository.cs
+++ b/TabloidMVC/Repositories/CommentRepository.cs
@@ -95,7 +95,7 @@ namespace TabloidMVC.Repositories
                     //create and execute command
                     cmd.CommandText = @"
                         SELECT Id, PostId, UserProfileId, [Subject], Content, CreateDateTime
-                        FROM Comment c
+                        FROM Comment
                         WHERE Id = @id
                     ";
 

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@model TabloidMVC.Models.ViewModels.PostCommentsViewModel
+﻿@using System.Security.Claims;
+@model TabloidMVC.Models.ViewModels.PostCommentsViewModel
 
 @{
     ViewData["Title"] = "Index";
@@ -46,12 +47,17 @@
                         @Html.DisplayFor(modelItem => item.CreateDateTime)
                     </td>
                     <td style="text-align: right">
-                        <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
-                            <i class="fas fa-pencil-alt"></i>
-                        </a>
-                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
-                            <i class="fas fa-trash"></i>
-                        </a>
+                        @if(int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) == item.UserProfileId)
+                        {
+                        
+                            <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                                <i class="fas fa-pencil-alt"></i>
+                            </a>
+                            <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                                <i class="fas fa-trash"></i>
+                            </a>
+                        
+                        }
                     </td>
                 </tr>
             }

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -47,16 +47,21 @@
                         @Html.DisplayFor(modelItem => item.CreateDateTime)
                     </td>
                     <td style="text-align: right">
-                        @if(int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) == item.UserProfileId)
+                        @if (int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) == item.UserProfileId)
                         {
-                        
+
                             <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
                                 <i class="fas fa-pencil-alt"></i>
                             </a>
                             <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
                                 <i class="fas fa-trash"></i>
                             </a>
-                        
+                        }
+                        @if (int.Parse(User.FindFirstValue(ClaimTypes.Role)) == 1 && int.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)) != item.UserProfileId)
+                        {
+                            <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                                <i class="fas fa-trash"></i>
+                            </a>
                         }
                     </td>
                 </tr>


### PR DESCRIPTION
Testing:
- Using SQL, create a new user with a usertype of author in the database and login as them
- Navigate to a post's comments, the edit and delete buttons should only show for comments of the currently logged in user
- Try to edit or delete a comment of a different user by entering a url
- Login as an admin and navigate to a post's comments
- An admin should be able to delete any comment, but only edit their own comment